### PR TITLE
Improve stability of library

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -149,7 +149,7 @@ void HTTPConnection::closeConnection() {
  * This method will try to fill up the buffer with data from
  */
 int HTTPConnection::updateBuffer() {
-  if (!isClosed()) {
+  if (!isClosed()||canReadData()) {
 
     // If there is buffer data that has been marked as processed.
     // Some example is shown here:

--- a/src/HTTPConnection.hpp
+++ b/src/HTTPConnection.hpp
@@ -6,7 +6,11 @@
 
 #include <string>
 #include <mbedtls/base64.h>
+#ifdef ESP32
+#include <sha/sha_parallel_engine.h>
+#else
 #include <hwcrypto/sha.h>
+#endif
 #include <functional>
 
 // Required for sockets


### PR DESCRIPTION
When data is not correctly read by the browser, the SSL_read appears to keep the data in buffer and eventually causes a Core 0 panic'ed. Checking if there is further data to be read and reading this data clears the buffer and stops the crash.